### PR TITLE
Support patching an array

### DIFF
--- a/src/mixins.js
+++ b/src/mixins.js
@@ -6,7 +6,11 @@ function patch(obj, patchObj) {
     const result = {};
     for (const [k, v] of Object.entries(obj)) {
       if (k in patchObj) {
-        result[k] = patch(v, patchObj[k]);
+        if (Array.isArray(v)) {
+          result[k] = patchObj[k];
+        } else {
+          result[k] = patch(v, patchObj[k]);
+        }
       } else {
         result[k] = v;
       }

--- a/tests/mixins.test.js
+++ b/tests/mixins.test.js
@@ -74,3 +74,21 @@ test('patches', () => {
     bar: 2
   });
 });
+
+test("array patch", () => {
+  const orig = {
+    foo: { bar: 1, ary: ["foo"] },
+    baz: 2
+  };
+
+  expect(patch(orig, { foo: { bar: 3, ary: ["bar"] } })).toEqual({
+    foo: { bar: 3, ary: ["bar"] },
+    baz: 2
+  });
+
+  // orig has been left untouched.
+  expect(orig).toEqual({
+    foo: { bar: 1, ary: ["foo"] },
+    baz: 2
+  });
+});


### PR DESCRIPTION
Hello!

I wanted to be able to work with arrays when using `patch`. This PR adds a naive implementation and test to hopefully start the discussion.

My use case was populating something at the `container` level of a kubernetes deployment, like so:
```js

const deployment = new k8s.apps.v1.Deployment(name, {
//....
  spec: {
    template: {
      spec: {
        containers: [
          {
            name: 'my-container',
            ports: [
              {
                containerPort: port,
                protocol: "TCP"
              }
            ]
          }
        ]
      }
    }
  }
});
for (const env of ["sandbox", "staging", "production"]) {
  const image = `gcr.io/berbix-${env}/themer-container:20190123t131309`;
  const withImage = obj => {
    const current = getNestedObject(obj, [
      "spec",
      "template",
      "spec",
      "containers"
    ]);
    return patch(obj, {
      spec: {
        template: {
          spec: {
            containers: current.map(c => ({ ...c, image }))
          }
        }
      }
    });
  };
  const p = mix(deployment, withImage);
  std.write(p, `${env}/themer-deployment.yaml`);
}
```
Really excited about this project!